### PR TITLE
[FEATURE] JWT 토큰 재발급 및 삭제

### DIFF
--- a/backend/src/main/java/kr/kh/backend/controller/UserController.java
+++ b/backend/src/main/java/kr/kh/backend/controller/UserController.java
@@ -138,14 +138,22 @@ public class UserController {
                 .build();
     }
 
-    // 토큰 갱신
+    // 토큰 재발급
     @PostMapping("/refreshToken")
-    public ResponseEntity<?> refreshToken(@RequestBody JwtToken jwtToken) {
-        log.info("액세스 토큰 갱신 요청 : 액세스 {}, 리프레시 {}", jwtToken.getAccessToken(), jwtToken.getRefreshToken());
+    public ResponseEntity<?> refreshToken(HttpServletResponse response) {
+        JwtToken newJwtToken = jwtTokenProvider.generateToken(SecurityContextHolder.getContext().getAuthentication());
 
+        Cookie refreshCookie = new Cookie("refreshToken", newJwtToken.getRefreshToken());
+        refreshCookie.setHttpOnly(true);
+        refreshCookie.setMaxAge(24 * 60 * 60);
+        refreshCookie.setSecure(false);
+        refreshCookie.setPath("/");
+        response.addCookie(refreshCookie);
 
         return ResponseEntity.ok()
-                .header("Authorization", "Bearer " + jwtToken.getAccessToken())
+                .header("Authorization", "Bearer " + newJwtToken.getAccessToken())
+                .header("Set-Cookie", "refreshToken=" + newJwtToken.getRefreshToken()
+                        + "; Path=/; HttpOnly; Max-Age=86400; SameSite=Lax" )
                 .build();
     }
 

--- a/backend/src/main/java/kr/kh/backend/domain/Token.java
+++ b/backend/src/main/java/kr/kh/backend/domain/Token.java
@@ -2,10 +2,11 @@ package kr.kh.backend.domain;
 
 import lombok.Getter;
 import lombok.Setter;
+import lombok.ToString;
 
 import java.util.Date;
 
-@Getter @Setter
+@Getter @Setter @ToString
 public class Token {
     private int id;
     private String token;

--- a/backend/src/main/java/kr/kh/backend/mapper/TokenMapper.java
+++ b/backend/src/main/java/kr/kh/backend/mapper/TokenMapper.java
@@ -1,18 +1,26 @@
 package kr.kh.backend.mapper;
 
 import kr.kh.backend.domain.Token;
-import org.apache.ibatis.annotations.Insert;
-import org.apache.ibatis.annotations.Mapper;
-import org.apache.ibatis.annotations.Select;
+import org.apache.ibatis.annotations.*;
 
 @Mapper
 public interface TokenMapper {
 
     @Insert("INSERT INTO token (token, user_id, expiration_date, status) " +
-            "VALUES (#{token}, #{userId}, #{expirationDate}, #{status})")
-    int saveToken(Token token);
+            "VALUES (#{token.token}, #{token.userId}, #{token.expirationDate}, #{token.status})")
+    int saveToken(@Param("token") Token token);
 
-    @Select("SELECT FROM token WHERE user_id = #{userId}")
-    Token getTokenByUserId(int userId);
+    @Select("SELECT * FROM token WHERE token = #{token}")
+    @Results({
+            @Result(property = "id", column = "id"),
+            @Result(property = "token", column = "token"),
+            @Result(property = "userId", column = "user_id"),
+            @Result(property = "expirationDate", column = "expiration_date"),
+            @Result(property = "status", column = "status")
+    })
+    Token getTokenByToken(String token);
+
+    @Update("UPDATE token SET status = #{token.status} WHERE token = #{token.token}")
+    int updateToken(@Param("token") Token token);
 
 }

--- a/backend/src/main/java/kr/kh/backend/mapper/TokenMapper.java
+++ b/backend/src/main/java/kr/kh/backend/mapper/TokenMapper.java
@@ -3,6 +3,8 @@ package kr.kh.backend.mapper;
 import kr.kh.backend.domain.Token;
 import org.apache.ibatis.annotations.*;
 
+import java.util.List;
+
 @Mapper
 public interface TokenMapper {
 
@@ -10,7 +12,7 @@ public interface TokenMapper {
             "VALUES (#{token.token}, #{token.userId}, #{token.expirationDate}, #{token.status})")
     int saveToken(@Param("token") Token token);
 
-    @Select("SELECT * FROM token WHERE token = #{token}")
+    @Select("SELECT * FROM token WHERE token = #{token} ORDER BY id DESC")
     @Results({
             @Result(property = "id", column = "id"),
             @Result(property = "token", column = "token"),
@@ -18,7 +20,7 @@ public interface TokenMapper {
             @Result(property = "expirationDate", column = "expiration_date"),
             @Result(property = "status", column = "status")
     })
-    Token getTokenByToken(String token);
+    List<Token> getTokenByToken(String token);
 
     @Update("UPDATE token SET status = #{token.status} WHERE token = #{token.token}")
     int updateToken(@Param("token") Token token);

--- a/backend/src/main/java/kr/kh/backend/security/jwt/JwtAuthFilter.java
+++ b/backend/src/main/java/kr/kh/backend/security/jwt/JwtAuthFilter.java
@@ -1,5 +1,7 @@
 package kr.kh.backend.security.jwt;
 
+import io.jsonwebtoken.Claims;
+import io.jsonwebtoken.Jwts;
 import jakarta.servlet.FilterChain;
 import jakarta.servlet.ServletException;
 import jakarta.servlet.ServletRequest;
@@ -53,12 +55,14 @@ public class JwtAuthFilter extends GenericFilterBean {
         } else if (refreshToken != null && jwtTokenProvider.validateRefreshToken(refreshToken)) {
             // 액세스 토큰이 없거나 혹은 유효하지 않지만 리프레시 토큰이 유효한 경우
             log.info("validate refresh token : {}", refreshToken);
+            Authentication authentication = jwtTokenProvider.createAuthentication(refreshToken);
+            SecurityContextHolder.getContext().setAuthentication(authentication);
         } else {
             // 둘다 유효하지 않은 경우
             httpResponse.sendError(HttpServletResponse.SC_UNAUTHORIZED, "Both access token and refresh token are invalid");
         }
 
-        log.info("success JWT Filter ! SecurityContextHolder = {}", SecurityContextHolder.getContext());
+        log.info("Result of JWT Filter ! SecurityContextHolder = {}", SecurityContextHolder.getContext());
         chain.doFilter(request, response);
     }
 
@@ -91,4 +95,5 @@ public class JwtAuthFilter extends GenericFilterBean {
         log.info("Refresh Token null");
         return "Refresh Token null";
     }
+
 }

--- a/backend/src/main/java/kr/kh/backend/security/jwt/JwtAuthFilter.java
+++ b/backend/src/main/java/kr/kh/backend/security/jwt/JwtAuthFilter.java
@@ -32,7 +32,7 @@ public class JwtAuthFilter extends GenericFilterBean {
         String path = ((HttpServletRequest) request).getRequestURI();
 
         // 모든 로그인 요청에 대해 예외 처리 (필터를 통과시킴)
-        if (path.startsWith("/form/") || path.startsWith("/login/")) {
+        if (path.startsWith("/form/") || path.startsWith("/login/") || path.startsWith("/ranking/")) {
             log.info("httpUri = {}", httpRequest.getRequestURI());
             chain.doFilter(request, response);
             return;

--- a/backend/src/main/java/kr/kh/backend/service/security/Oauth2UserService.java
+++ b/backend/src/main/java/kr/kh/backend/service/security/Oauth2UserService.java
@@ -197,9 +197,7 @@ public class Oauth2UserService extends DefaultOAuth2UserService {
         String role = "USER";
 
         // 해당 유저가 디비에 있는지 확인
-        log.info("mybatis 전");
         User user = userMapper.findByUsername(username);
-        log.info("mybatis 후");
 
         if(user == null) {
             log.info("등록되지 않은 oauth 사용자 입니다. 디비에 사용자 정보를 저장합니다.");

--- a/frontend/src/components/Modal/Modal.jsx
+++ b/frontend/src/components/Modal/Modal.jsx
@@ -181,8 +181,15 @@ const Modal = ({ type, closeModal }) => {
 
   // 네이버 로그인
   const doNaverLogin = () => {
-    console.log("Naver login function called.");
-    window.location.href = "http://localhost:8080";
+    let state = encodeURI(process.env.REACT_APP_NAVER_REDIRECT_URI);
+    window.location.href =
+      "https://nid.naver.com/oauth2.0/authorize?response_type=code" +
+      "&client_id=" +
+      process.env.REACT_APP_NAVER_CLIENT_ID +
+      "&redirect_uri=" +
+      process.env.REACT_APP_NAVER_REDIRECT_URI +
+      "&state=" +
+      state;
   };
 
   // 깃허브 로그인 페이지로 전송

--- a/frontend/src/components/Modal/Modal.jsx
+++ b/frontend/src/components/Modal/Modal.jsx
@@ -95,17 +95,25 @@ const Modal = ({ type, closeModal }) => {
           headers: {
             "Content-Type": "application/json",
           },
+          withCredentials: true,
         },
       );
 
-      const { accessToken, refreshToken } = response.data;
+      if (response.status === 400) {
+        navigate("/");
+        alert("사용자 정보가 없습니다. 로그인을 다시 시도해주세요.");
+      }
 
-      sessionStorage.setItem("accessToken", accessToken);
-      sessionStorage.setItem("refreshToken", refreshToken);
+      if (response.status === 200) {
+        const data = await response.headers.get("Authorization");
+        const accessToken = data.split(" ")[1];
+        sessionStorage.setItem("accessToken", accessToken);
+        response.headers.get("Set-Cookie");
 
-      window.location.reload();
-      // navigate("/");
-      closeModal();
+        window.location.reload();
+        navigate("/");
+        closeModal();
+      }
     } catch (err) {
       console.error(
         "login error:",

--- a/frontend/src/components/Nav/Nav.jsx
+++ b/frontend/src/components/Nav/Nav.jsx
@@ -9,21 +9,32 @@ const Nav = ({ username }) => {
   const [isListOpen, setIsListOpen] = useState(false);
   const [isProfileOpen, setIsProfileOpen] = useState(false);
   const [windowWidth, setWindowWidth] = useState(window.innerWidth);
-  const [isToken, setIsToken] = useState(null);
-  const token = sessionStorage.getItem("accessToken");
+  const [isToken, setIsToken] = useState(false);
   const navigate = useNavigate();
 
   const { name: subjectName } = useParams();
 
-  useEffect(() => {
-    const storedToken = sessionStorage.getItem("accessToken");
+  const getAccessToken = () => {
+    const token = sessionStorage.getItem("accessToken");
+    if (!token) return null;
 
-    if (storedToken) {
-      setIsToken(storedToken);
-    } else {
-      handleUpdateToken();
+    try {
+      const payload = JSON.parse(atob(token.split(".")[1]));
+      const exp = payload.exp * 1000;
+      const currentTime = new Date().getTime();
+
+      if (currentTime > exp) {
+        sessionStorage.removeItem("accessToken");
+        return null;
+      }
+
+      return token;
+    } catch (error) {
+      console.error("토큰 검증 중 오류:", error);
+      sessionStorage.removeItem("accessToken");
+      return null;
     }
-  }, []);
+  };
 
   const handleUpdateToken = async () => {
     try {
@@ -33,27 +44,43 @@ const Nav = ({ username }) => {
           "Content-Type": "application/json",
         },
         credentials: "include",
-      }).catch(err => console.log(err));
+      });
 
       if (response.ok) {
         const newAccessToken = response.headers.get("Authorization");
-        console.log(newAccessToken);
-        const accessToken = newAccessToken.split(" ")[1];
-        sessionStorage.setItem("accessToken", accessToken);
-        response.headers.get("Set-Cookie");
+        if (newAccessToken) {
+          const accessToken = newAccessToken.split(" ")[1];
 
-        // navigate("/");
-        window.location.reload();
+          sessionStorage.setItem("accessToken", accessToken);
+          response.headers.get("Set-Cookie");
+
+          setIsToken(true);
+          window.location.reload();
+        }
       }
 
       if (response.status === 401) {
-        alert("사용자 정보가 만료되었습니다. 다시 로그인 해주세요.");
-        navigate("/");
+        setIsToken(false);
+        // alert("사용자 정보가 만료되었습니다. 다시 로그인 해주세요.");
+        // navigate("/");
       }
     } catch (error) {
-      console.log("요청 중 오류가 발생했습니다", error);
+      console.error("토큰 갱신 중 오류 발생", error);
+      setIsToken(false);
+      // navigate("/");
     }
   };
+
+  // 로그인 유지를 위한 토큰 검증
+  useEffect(() => {
+    const token = getAccessToken();
+
+    if (token) {
+      setIsToken(true);
+    } else {
+      handleUpdateToken();
+    }
+  }, []);
 
   const openModal = type => {
     setModalType(type);
@@ -74,8 +101,28 @@ const Nav = ({ username }) => {
   };
 
   const logout = () => {
+    navigate("/");
+    setIsToken(false);
     sessionStorage.removeItem("accessToken");
-    window.location.reload();
+    deleteCookie();
+  };
+
+  const deleteCookie = async () => {
+    try {
+      const response = await fetch("http://localhost:8080/form/logout", {
+        method: "POST",
+        credentials: "include",
+      });
+
+      if (response.ok) {
+        console.log("로그아웃 성공");
+        sessionStorage.removeItem("accessToken");
+        window.location.reload();
+        navigate("/");
+      }
+    } catch (error) {
+      console.error("로그아웃 실패", error);
+    }
   };
 
   useEffect(() => {
@@ -103,7 +150,7 @@ const Nav = ({ username }) => {
       <ControllerBox>
         {windowWidth > 720 && (
           <>
-            {!token ? (
+            {!isToken ? (
               <>
                 <Login onClick={() => openModal("login")}>로그인</Login>
                 <Register onClick={() => openModal("register")}>
@@ -131,7 +178,7 @@ const Nav = ({ username }) => {
         )}
         {windowWidth <= 720 && (
           <>
-            {!token ? (
+            {!isToken ? (
               <>
                 <ListIcon className="bi bi-list" onClick={openList} />
                 {isListOpen && (

--- a/frontend/src/components/Nav/Nav.jsx
+++ b/frontend/src/components/Nav/Nav.jsx
@@ -17,10 +17,43 @@ const Nav = ({ username }) => {
 
   useEffect(() => {
     const storedToken = sessionStorage.getItem("accessToken");
+
     if (storedToken) {
       setIsToken(storedToken);
+    } else {
+      handleUpdateToken();
     }
-  }, [token]);
+  }, []);
+
+  const handleUpdateToken = async () => {
+    try {
+      const response = await fetch("http://localhost:8080/refreshToken", {
+        method: "POST",
+        headers: {
+          "Content-Type": "application/json",
+        },
+        credentials: "include",
+      }).catch(err => console.log(err));
+
+      if (response.ok) {
+        const newAccessToken = response.headers.get("Authorization");
+        console.log(newAccessToken);
+        const accessToken = newAccessToken.split(" ")[1];
+        sessionStorage.setItem("accessToken", accessToken);
+        response.headers.get("Set-Cookie");
+
+        // navigate("/");
+        window.location.reload();
+      }
+
+      if (response.status === 401) {
+        alert("사용자 정보가 만료되었습니다. 다시 로그인 해주세요.");
+        navigate("/");
+      }
+    } catch (error) {
+      console.log("요청 중 오류가 발생했습니다", error);
+    }
+  };
 
   const openModal = type => {
     setModalType(type);

--- a/frontend/src/index.js
+++ b/frontend/src/index.js
@@ -9,11 +9,10 @@ import "./index.css";
 const root = ReactDOM.createRoot(document.getElementById("root"));
 
 root.render(
-  <React.StrictMode>
-    <ThemeProvider theme={theme}>
-      <GlobalStyle />
-      <Router />
-    </ThemeProvider>
-    ,
-  </React.StrictMode>,
+  // <React.StrictMode>
+  <ThemeProvider theme={theme}>
+    <GlobalStyle />
+    <Router />
+  </ThemeProvider>,
+  // </React.StrictMode>,
 );

--- a/frontend/src/pages/Main/Main.jsx
+++ b/frontend/src/pages/Main/Main.jsx
@@ -5,7 +5,6 @@ import styled from "styled-components";
 import "slick-carousel/slick/slick.css";
 import "slick-carousel/slick/slick-theme.css";
 import useResponsive from "../../hooks/useResponsive";
-import useTokenFunction from "../../hooks/useTokenFunction";
 
 const Main = () => {
   const navigate = useNavigate();
@@ -51,7 +50,7 @@ const Main = () => {
       // 쿠키도 추가해야해 !!!!!
       response.headers.get("Set-Cookie");
       navigate("/");
-      // window.location.reload();
+      window.location.reload();
     } else {
       console.error("Failed to fetch token");
     }
@@ -82,7 +81,7 @@ const Main = () => {
       response.headers.get("Set-Cookie");
 
       navigate("/");
-      // window.location.reload();
+      window.location.reload();
     } else {
       console.error("Failed to fetch token");
     }

--- a/frontend/src/pages/Main/Main.jsx
+++ b/frontend/src/pages/Main/Main.jsx
@@ -51,7 +51,7 @@ const Main = () => {
       // 쿠키도 추가해야해 !!!!!
       response.headers.get("Set-Cookie");
       navigate("/");
-      window.location.reload();
+      // window.location.reload();
     } else {
       console.error("Failed to fetch token");
     }
@@ -82,7 +82,7 @@ const Main = () => {
       response.headers.get("Set-Cookie");
 
       navigate("/");
-      window.location.reload();
+      // window.location.reload();
     } else {
       console.error("Failed to fetch token");
     }

--- a/frontend/src/pages/Main/NcpMain.jsx
+++ b/frontend/src/pages/Main/NcpMain.jsx
@@ -7,7 +7,6 @@ import "slick-carousel/slick/slick-theme.css";
 import RankChart from "../../components/Charts/RankChart";
 import axios from "axios";
 import useResponsive from "../../hooks/useResponsive";
-import axiosConfig from "../../utils/axiosConfig";
 
 const NcaMain = () => {
   const navigate = useNavigate();

--- a/frontend/src/pages/Main/NcpMain.jsx
+++ b/frontend/src/pages/Main/NcpMain.jsx
@@ -20,8 +20,8 @@ const NcaMain = () => {
   }, []);
 
   const getRankingData = async () => {
-    const response = await axiosConfig
-      .post(`/ranking/v2`, {
+    const response = await axios
+      .post(`http://localhost:8080/ranking/v2`, {
         title: "NCP",
       })
       .catch(err => {

--- a/frontend/src/utils/axiosConfig.js
+++ b/frontend/src/utils/axiosConfig.js
@@ -1,59 +1,24 @@
 import axios from "axios";
 
 const axiosConfig = axios.create({
-  baseURL: process.env.REACT_APP_BASE_URL,
-  withCredentials: true,
+  baseURL: "http://localhost:8080",
 });
 
 axiosConfig.interceptors.request.use(
-  async config => {
-    const accessToken = sessionStorage.getItem("accessToken");
-    const refreshToken = getCookie("refreshToken");
-
-    // 액세스 토큰이 있는 경우
-    if (accessToken) {
-      config.headers["Authorization"] = `Bearer ${accessToken}`;
-    }
-
-    // 액세스 토큰이 없는데 리프레시 토큰이 있는 경우 : 서버로 재발행 요청 후 새로 받은 액세스 토큰을 요청 헤더에 추가.
-    else if (refreshToken) {
-      try {
-        const response = await axios.post(
-          `${process.env.REACT_APP_BASE_URL}/refreshToken`,
-          { refreshToken },
-          { withCredentials: true },
-        );
-
-        const newAccessToken = response.data.accessToken;
-
-        sessionStorage.setItem("accessToken", newAccessToken);
-        config.headers["Authorization"] = `Bearer ${newAccessToken}`;
-      } catch (error) {
-        return Promise.reject(
-          new axios.Cancel("리프레시 토큰 갱신 실패.", error),
-        );
-      }
-    }
-
-    // 액세스, 리프레시 토큰 둘 다 없는 경우 : 사용자에게 로그인 요청!
-    else {
+  config => {
+    const token = sessionStorage.getItem("accessToken");
+    if (token) {
+      config.headers["Authorization"] = `Bearer ${token}`;
+    } else {
       return Promise.reject(
         new axios.Cancel("토큰이 없습니다. 다시 로그인 해주세요"),
       );
     }
-
     return config;
   },
   error => {
     return Promise.reject(error);
   },
 );
-
-function getCookie(name) {
-  const value = `; ${document.cookie}`;
-  const parts = value.split(`; ${name}=`);
-  if (parts.length === 2) return parts.pop().split(";").shift();
-  return null;
-}
 
 export default axiosConfig;


### PR DESCRIPTION
#### 1️⃣ 기능 설명 : 토큰 재발급을 통해 사용자의 로그인 상태를 유지하고, 로그아웃시 기 발행된 토큰을 삭제한다.

#### 2️⃣ 상세 Flow :

* [ Action "사용자의 로그인" ] => access token, refresh token 생성
    * access token
        * 브라우저 세션 스토리지에 저장
    * refresh token 
        * http only 쿠키에 저장
        * DB에 저장

``` sql
create table token(
id int primary key auto_increment,
token varchar(255),
user_id int,
expiration_date datetime,
status varchar(255)); #VALID, USED, EXPIRED
```


* [ CASE "사용자의 재접속" ] => 리액트 'Nav.jsx' 에서 access token 존재 및 만료 여부를 확인한다. 만약 만료되었다면 access token 을 세션 스토리지에서 삭제한다.
    * WHEN "access token, refresh token 둘 다 남아있다" 
        * THEN "계속해서 로그인 유지"
    * WHEN "access token 사라졌고, refresh token 남아있다" 
        * THEN "남아있는 refresh token 으로 access token 재발급 요청"
        * (1) refresh token 유효성 확인
            * 서명 검증 : 우리 서버에서 발행한 토큰이 맞는지 확인
            * DB 조회 (status 확인, 만료 기한 확인) : status = VALID && 만료 기한이 재발급 요청 시간보다 길다면 유효한 토큰인 것으로 간주함.
        * (2) refresh token 을 사용처리 : status.USED 로 UPDATE 쿼리문 실행
        * (3) refresh token 의 username 정보로 새로운 access token 발행. 이 때 refresh token 도 새로 발행해준다.
        * (4) 새로 발행한 액세스 토큰을 리턴하면 다시 세션 스토리지에 저장함으로써 로그인 유지.
    * WHEN "access token, refresh token 둘 다 사라졌다"
        * THEN "사용자를 로그인 페이지 ("/") 로 전송한다"



* [ Action "사용자의 로그아웃" ]
    * access token
        * 세션 스토리지에서 제거
    * refresh token
        * DB에서 제거 : status.EXPIRED 로 UPDATE 쿼리문 실행
        * 쿠키 만료시간을 0으로 변경하여 제거



#### 3️⃣ 구현 : 

####  [ Nav.jsx ]

 토큰 만료 확인
- Nav 바는 NCBT 서비스에서 제공하는 모든 페이지에 띄워지기에, 처음 마운트되었을 때 access token 을 확인하도록 하고, 기한이 만료되었다면 세션 스토리지에서 제거하도록 했다.

토큰 재발급 요청
 - 액세스 토큰이 없는 상태라면 리프레쉬 토큰을 서버로 전송해 토큰 재발급을 요청한다.
- 토큰을 재발급 받았을 경우, 페이지를 리로드하여 사용자가 이용중이던 페이지에 머물도록 구현했다.


#### [ "/refreshToken" API ]

JwtAuthFilter
- 해당 API 로 토큰 갱신 요청이 들어오면 시큐리티 필터를 거쳐서 access token, refresh token 이 유효한지 확인한다.
- 어느 것 하나라도 유효하다면 인증 객체를 만들고 컨트롤러로 진행, 유효하지 않다면 401 상태코드 반환.
- 이후 컨트롤러 단에서 토큰을 재발급하여 각각 response header 와 쿠키로 전송한다.


#### [ "/form/logout" API ]

logout 컨트롤러
- 해당 API 로 로그아웃 요청이 들어오는 경우 시큐리티 필터를 거치지 않도록 구현했다. 
- DB 에 저장된 refresh token 을 EXPIRED 로 변경한다.
- 쿠키의 만료시간을 0 으로 변경하는 것으로 삭제한다.
